### PR TITLE
fix: デプロイエラーの修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,5 +23,9 @@ test:
 # Store production database in the storage/ directory, which by default
 # is mounted as a persistent Docker volume in config/deploy.yml.
 production:
-  <<: *default
-  url: <%= ENV['DATABASE_URL'] %>
+  primary: &primary_production
+    adapter: postgresql
+    url: <%= ENV["DATABASE_URL"] %>
+  cable:
+    <<: *primary_production
+    migrations_paths: db/cable_migrate


### PR DESCRIPTION
## 概要
Rails 8から標準搭載された Solid Cable が、本番環境（production）においてデータベース設定を参照できず、アプリケーションの起動に失敗する問題を解消しました。

## 変更内容
* config/database.yml の production セクションを修正。
* primary（メインDB）の設定を YAML のアンカー（&primary_production）として定義。
* cable（Solid Cable用）の設定で上記アンカーをエイリアス（*primary_production）として呼び出し、メインDB（Neon）を共有するように設定。
* migrations_paths を明示し、Solid Cable用のマイグレーションが正しく実行されるように構成。