### PR TITLE
fix:（Cable/Cache/Queue）の本番環境DB設定を完備

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -29,3 +29,9 @@ production:
   cable:
     <<: *primary_production
     migrations_paths: db/cable_migrate
+  cache:
+    <<: *primary_production
+    migrations_paths: db/cache_migrate
+  queue:
+    <<: *primary_production
+    migrations_paths: db/queue_migrate


### PR DESCRIPTION
## 概要
Rails 8で標準採用された Solid Cable、Solid Cache、Solid Queue の3つのコンポーネントが、本番環境（production）においてデータベース設定を参照できず、アプリケーションの起動に失敗する問題を解消しました。

## 変更内容
config/database.yml の production セクションを修正。

以下のコンポーネントに対して、メインDB（primary）の設定を共有するよう定義を追加しました。
* cable: リアルタイム通信用
* cache: キャッシュデータ用
* queue: バックグラウンドジョブ用
* それぞれのコンポーネントに対し、専用の migrations_paths を設定しました。