### PR TITLE
fix: 本番環境での画像表示設定の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,9 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+# Use Cloudinary for cloud-based image storage
+gem "cloudinary"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cloudinary (2.4.3)
+      faraday (>= 2.0.1, < 3.0.0)
+      faraday-follow_redirects (~> 0.5)
+      faraday-multipart (~> 1.0, >= 1.0.4)
+      ostruct
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -114,6 +119,16 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
     ffi (1.17.3-arm-linux-gnu)
@@ -175,6 +190,9 @@ GEM
     minitest (6.0.1)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.2)
       date
       net-protocol
@@ -400,6 +418,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara
+  cloudinary
   debug
   image_processing (~> 1.2)
   importmap-rails

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -40,6 +40,9 @@ registry:
 env:
   secret:
     - RAILS_MASTER_KEY
+    - CLOUDINARY_CLOUD_NAME
+    - CLOUDINARY_API_KEY
+    - CLOUDINARY_API_SECRET
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,6 +26,9 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
+  
+  # Active Storageのルーティングを有効にする
+  config.active_storage.resolve_model_to_route = :rails_storage_proxy
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
 
   # Store uploaded files with Cloudinary in production
   config.active_storage.service = :cloudinary
-  
+
   # Active Storageのルーティングを有効にする
   config.active_storage.resolve_model_to_route = :rails_storage_proxy
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,8 +24,8 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # Store uploaded files with Cloudinary in production
+  config.active_storage.service = :cloudinary
   
   # Active Storageのルーティングを有効にする
   config.active_storage.resolve_model_to_route = :rails_storage_proxy

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,13 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+# Use Cloudinary for cloud-based image storage
+cloudinary:
+  service: Cloudinary
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
## 問題
本番環境でActive Storageにアップロードした画像が表示されない問題が発生していました。

## 原因
本番環境での静的ファイル配信設定が不足していた
Dockerコンテナ環境でローカルストレージを使用していたため、画像の永続化ができていなかった。

## 対応内容
1. 静的ファイル配信の設定追加
Active Storageのルーティングプロキシ設定を追加
対象ファイル
`production.rb`

2. Cloudinaryの導入
本番環境でCloudinaryを使用するように設定変更
対象ファイル
`Gemfile`
`storage.yml`
`deploy.yml`

その他、Renderの環境変数の設定変更