### PR TITLE
fix: CloudinaryのURLを直接使用するように設定変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,9 +27,6 @@ Rails.application.configure do
   # Store uploaded files with Cloudinary in production
   config.active_storage.service = :cloudinary
 
-  # Active Storageのルーティングを有効にする
-  config.active_storage.resolve_model_to_route = :rails_storage_proxy
-
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true
 


### PR DESCRIPTION
## 問題
本番環境でActive Storageの画像を表示しようとすると500エラーが発生していました。

## 原因
production.rbの設定により、Railsサーバーがプロキシとして画像配信を試みていたが、Renderの環境でこれが失敗していた。

## 対応内容
resolve_model_to_route 設定を削除
(config.active_storage.resolve_model_to_route = :rails_storage_proxy)

## 動作確認
* 本番環境で画像が正常に表示されること
* 画像URLがCloudinaryのドメインであること