### PR TITLE
feat: 画像解析を同期処理に変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,6 +27,9 @@ Rails.application.configure do
   # Store uploaded files with Cloudinary in production
   config.active_storage.service = :cloudinary
 
+  # 画像解析を非同期（バックグラウンド）で行わない設定
+  config.active_storage.analyze_active_job = false
+
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true
 


### PR DESCRIPTION
## 問題
本番環境で画像をアップロードした際、バックグラウンドジョブでの画像解析が原因で問題が発生する可能性があった。

## 対応内容
画像解析を非同期（バックグラウンド）で行わない設定
production.rbに
  config.active_storage.analyze_active_job = falseを追加

## 効果
画像アップロード時に解析が即座に完了する。