### PR TITLE
fix: CloudinaryのURLを直接使用するようにビューを修正

### DIFF
--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,7 +1,7 @@
 <p><%= link_to "Back", products_path %></p>
 
 <section class="product">
-  <%= image_tag @product.featured_image if @product.featured_image.attached? %>
+  <%= image_tag @product.featured_image.url if @product.featured_image.attached? %>
 
   <section class="product-info">
     <% cache @product do %>

--- a/app/views/store/products/show.html.erb
+++ b/app/views/store/products/show.html.erb
@@ -1,7 +1,7 @@
 <p><%= link_to "Back", store_products_path %></p>
 
 <section class="product">
-  <%= image_tag @product.featured_image if @product.featured_image.attached? %>
+  <%= image_tag @product.featured_image.url if @product.featured_image.attached? %>
 
   <section class="product-info">
     <% cache @product do %>


### PR DESCRIPTION
## 問題
本番環境で画像を表示しようとすると500エラーが発生していました。
エラーログを確認すると、/rails/active_storage/blobs/redirect/... というRailsのエンドポイントを経由して画像を取得しようとして失敗していました。

## 原因
ビューで image_tag @product.featured_image を使用していたため、RailsがActive Storageのリダイレクトエンドポイントを経由して画像を配信しようとしていました。Cloudinaryを使用している場合、このエンドポイントを経由する必要はなく、直接CloudinaryのURLを使用すべきだと考えました。

## 対応内容
* show.html.erbで image_tag @product.featured_image.url に変更
* show.html.erbで image_tag @product.featured_image.url に変更