### PR TITLE
fix: Solid Queueを無効化してジョブを同期実行に変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
 
   # 画像解析を非同期（バックグラウンド）で行わない設定
   config.active_storage.analyze_active_job = false
-  
+
   # ジョブをバックグラウンドではなく、その場で即座に実行する設定
   config.active_job.queue_adapter = :inline
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,6 +29,9 @@ Rails.application.configure do
 
   # 画像解析を非同期（バックグラウンド）で行わない設定
   config.active_storage.analyze_active_job = false
+  
+  # ジョブをバックグラウンドではなく、その場で即座に実行する設定
+  config.active_job.queue_adapter = :inline
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true
@@ -56,8 +59,8 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  # config.active_job.queue_adapter = :solid_queue
+  # config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
## 問題
本番環境でページを表示しようとすると500エラーが発生していました。

## 原因
Solid Queueが本番環境（Render）で正しく動作しておらず、Active Jobを使用する処理（画像解析、通知メールなど）が失敗していました。

## 対応内容
`production.rb`にて
`config.active_job.queue_adapter = :inline`を追記
以下をコメントアウト
`config.active_job.queue_adapter = :solid_queue`
`config.solid_queue.connects_to = { database: { writing: :queue } }`