### PR TITLE
fix: activestorage-cloudinary-service gemを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "image_processing", "~> 1.2"
 
 # Use Cloudinary for cloud-based image storage
 gem "cloudinary"
+gem "activestorage-cloudinary-service"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       activerecord (= 8.1.2)
       activesupport (= 8.1.2)
       marcel (~> 1.0)
+    activestorage-cloudinary-service (0.2.3)
     activesupport (8.1.2)
       base64
       bigdecimal
@@ -413,6 +414,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  activestorage-cloudinary-service
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman


### PR DESCRIPTION
## 問題
本番環境で商品ページを表示しようとすると500エラーが発生していました。Cloudinaryの環境変数は正しく設定されているにもかかわらず、Active Storageが正しく動作していませんでした。

## 原因
Active StorageでCloudinaryを使用するには、gem "cloudinary"だけでなく、gem "activestorage-cloudinary-service"も必要であったのではと考えられる。

## 参考
https://rubygems.org/gems/activestorage-cloudinary-service